### PR TITLE
Fixed issue 8 (dot shows next to icons)

### DIFF
--- a/chrome/td.user.js
+++ b/chrome/td.user.js
@@ -758,10 +758,11 @@
                    // if buttons aria-label starts with a digit, it has a count
                    let buttonLabel = buttons[i].attr('aria-label');
                    let buttonTest = buttons[i].attr('data-testid');
-
+                   
+                    
                    // if buttonLabel starts w/ a num then there's a metric for this button
                    // OR if the button's data-testid is undefined, then it's *going* to get updated by React
-                   if(buttonLabel != null && buttonLabel.match(/^\d/)) {
+                   if(buttonLabel != null && buttonLabel.match(/^\d/)!= 0 ) {
                       if($(buttons[i]).hasClass("dotted")) return; 
                       else {
                         $(buttons[i]).addClass("dotted");


### PR DESCRIPTION
The dot only shows next to metrics greater than 0. Fixed issue 8 on chrome. 
<img width="1280" alt="Screen Shot 2020-09-09 at 10 28 53 PM" src="https://user-images.githubusercontent.com/14083340/92679418-fe8c4d00-f2ed-11ea-8e30-f10c1559a0d8.png">
