### PR TITLE
Hotfix/dot on individual tweets

### DIFF
--- a/chrome/td.user.js
+++ b/chrome/td.user.js
@@ -758,7 +758,7 @@
 
                 var dot;
 
-                console.log(!replyButton.attr('aria-label'));
+                
                 //console.log($(e.nextElementSibling).find('div[data-testid="reply"]'));
                 
                 if(demetricated) dot = '<sup class="button_dot demetricated" style="font-size:120%;font-weight:bold;font-family:serif;opacity:0.5;margin:-24px 0 0 2px;">.</sup>';
@@ -772,8 +772,7 @@
                    let buttonLabel = buttons[i].attr('aria-label');
                    let buttonTest = buttons[i].attr('data-testid');
                    
-                    console.log(buttonLabel)
-                    console.log(buttonTest)
+
                    // if buttonLabel starts w/ a num then there's a metric for this button
                    // OR if the button's data-testid is undefined, then it's *going* to get updated by React
                    if(buttonLabel != null && buttonLabel.match(/^\d/)!= 0 ) {

--- a/chrome/td.user.js
+++ b/chrome/td.user.js
@@ -741,14 +741,26 @@
                 let singleTweetTest = $(e).css('height');
                 if(singleTweetTest.match(/4/) != null) return;
                 */
-
+                
                 var replyButton = $(e).find('div[data-testid="reply"]');
+                if(!replyButton.attr('aria-label')){
+                    replyButton = $(e.nextElementSibling).find('div[data-testid="reply"]');
+                }
                 var retweetButton = $(e).find('div[data-testid="retweet"]');
+                if(!retweetButton.attr('aria-label')){
+                    retweetButton = $(e.nextElementSibling).find('div[data-testid="retweet"]');
+                }
                 var favoriteButton = $(e).find('div[data-testid="like"]');
+                if(!favoriteButton.attr('aria-label')){
+                    favoriteButton = $(e.nextElementSibling).find('div[data-testid="like"]');
+                }
                 var buttons = [replyButton, retweetButton, favoriteButton];
 
                 var dot;
 
+                console.log(!replyButton.attr('aria-label'));
+                //console.log($(e.nextElementSibling).find('div[data-testid="reply"]'));
+                
                 if(demetricated) dot = '<sup class="button_dot demetricated" style="font-size:120%;font-weight:bold;font-family:serif;opacity:0.5;margin:-24px 0 0 2px;">.</sup>';
                 else dot = '<sup class="button_dot demetricated" style="font-size:120%;font-weight:bold;font-family:serif;opacity:0.5;margin:-24px 0 0 2px;display:none;">.</sup>';
 
@@ -756,10 +768,12 @@
                 // for every button, check and add dot if needed
                 for(var i = 0; i < buttons.length; i++) {
                    // if buttons aria-label starts with a digit, it has a count
+                   //console.log(buttons[i])
                    let buttonLabel = buttons[i].attr('aria-label');
                    let buttonTest = buttons[i].attr('data-testid');
                    
-                    
+                    console.log(buttonLabel)
+                    console.log(buttonTest)
                    // if buttonLabel starts w/ a num then there's a metric for this button
                    // OR if the button's data-testid is undefined, then it's *going* to get updated by React
                    if(buttonLabel != null && buttonLabel.match(/^\d/)!= 0 ) {
@@ -768,7 +782,7 @@
                         $(buttons[i]).addClass("dotted");
                         $(dot).insertAfter($(buttons[i]).find('svg').parent());
                       }
-                   } 
+                   }
                  }
             });
 


### PR DESCRIPTION
As seen in the image: the dots don't appear next to the main tweet when clicked on the tweet from Home page
<img width="1279" alt="Screen Shot 2020-09-15 at 5 01 35 PM" src="https://user-images.githubusercontent.com/14083340/93289187-6c7bbd00-f7a3-11ea-8090-ecf78771bce1.png">
Fixed this issue:
<img width="1280" alt="Screen Shot 2020-09-15 at 10 24 15 PM" src="https://user-images.githubusercontent.com/14083340/93289234-8a492200-f7a3-11ea-92c8-2fe8b8440c23.png">

(Just noticed the time stamps are also not hidden in this view)

