### PR TITLE
From [NAME] incorrectly hidden

### DIFF
--- a/chrome/td.css
+++ b/chrome/td.css
@@ -64,4 +64,3 @@ span span.r-jwli3a // following/followers on profile 3/25
 {
     display:none;
 }
-

--- a/chrome/td.user.js
+++ b/chrome/td.user.js
@@ -827,7 +827,6 @@
                 let curr_parent = $(e).children()[1];
                 let views_div = $(curr_parent).children()[1];
 
-                console.log($(e));
                 if($(views_div).hasClass("demetricator_checked")) return;
                 else $(views_div).addClass("demetricator_checked");
                 cloneAndDemetricateLeadingNum2($(views_div), "views");

--- a/chrome/td.user.js
+++ b/chrome/td.user.js
@@ -825,8 +825,7 @@
             ready('div[data-testid = "previewInterstitial"]', function(e) {
                 let curr_parent = $(e).children()[1];
                 let views_div = $(curr_parent).children()[1];
-                //console.log($(e).children()[1]);
-                //console.log($(curr_parent).children()[1]);
+
                 if($(views_div).hasClass("demetricator_checked")) return;
                 else $(views_div).addClass("demetricator_checked");
                 cloneAndDemetricateLeadingNum2($(views_div), "views");
@@ -835,25 +834,23 @@
             ready('div[data-testid = "videoPlayer"]', function(e) {
                 let curr_parent = $(e).children()[1];
                 let views_div = $(curr_parent).children()[1];
-                //console.log(e);
-                //console.log($(e).children()[1]);
-                //console.log($(curr_parent).children()[1]);
+
                 if($(views_div).hasClass("demetricator_checked")) return;
                 else $(views_div).addClass("demetricator_checked");
                 cloneAndDemetricateLeadingNum2($(views_div), "views");
             });
 
-            ready('div[data-testid = "placementTracking"]', function(e) {
-                let curr_parent = $(e).children()[1];
-                let views_div = $(curr_parent).children()[1];
-                console.log($("(e):contains('views')"));
-                //console.log($($(e).find('span')));
-                if($(views_div).hasClass("demetricator_checked")) return;
-                else $(views_div).addClass("demetricator_checked");
-                cloneAndDemetricateLeadingNum2($(views_div), "views");
+            ready('div[data-testid = "placementTracking"] span:nth-child(1)', function(e) {
+                var txt = ($(e).text()).trim();
+                console.log(txt.includes("views"));
+                console.log($(e).text);
+                if(txt.includes("views")){
+                    if($(e).hasClass("demetricator_checked")) return;
+                    else $(e).addClass("demetricator_checked");
+                    cloneAndDemetricateLeadingNum2($(e), "views");
+                }                
             });
 
-            //<span class="css-901oao css-16my406 r-1qd0xha r-ad9z0x r-bcqeeo r-qvutc0">88K views</span>
 
             ready('span[data-testid="viewCount"] span, div[data-testid="viewCount"] span', function(e) {
                 

--- a/chrome/td.user.js
+++ b/chrome/td.user.js
@@ -113,7 +113,7 @@
     // a few metrics are easy, hidden via CSS. this style is mirrored in 
     // twitterdemetricator.css in order to inject *before* DOM renders on
     // first load, so need to maintain state in these vars plus that file
-    var demetricatedStyle = '.ProfileCardStats-statValue, .ProfileTweet-actionCountForPresentation, .ProfileNav-value, a[data-tweet-stat-count] strong, .ep-MetricAnimation, .ep-MetricValue, .MomentCapsuleLikesFacepile-countNum, .stats li a strong { opacity:0 !important; } .count-wrap { display:hide !important; } div:not(.ProfileTweet-actionList)[aria-label="Tweet actions"] span, div[data-testid="like"] div span, div[data-testid="unlike"] div span, div[data-testid="reply"] div span, div[data-testid="retweet"] div span, div[data-testid="unretweet"] div span, div.r-z2knda.r-1wbh5a2 a > span:first-child, a.r-jwli3a[aria-haspopup] span div div, div.r-7o8qx1 div.r-axxi2z, div.css-1dbjc4n a.css-4rbku5 span.r-vw2c0b, span span.r-jwli3a { display:none; } '; 
+    var demetricatedStyle = '.ProfileCardStats-statValue, .ProfileTweet-actionCountForPresentation, .ProfileNav-value, a[data-tweet-stat-count] strong, .ep-MetricAnimation, .ep-MetricValue, .MomentCapsuleLikesFacepile-countNum, .stats li a strong { opacity:0 !important; } .count-wrap { display:hide !important; } div:not(.ProfileTweet-actionList)[aria-label="Tweet actions"] span, div[data-testid="like"] div span, div[data-testid="unlike"] div span, div[data-testid="reply"] div span, div[data-testid="retweet"] div span, div[data-testid="unretweet"] div span, div.r-z2knda.r-1wbh5a2 a > span:first-child, a.r-jwli3a[aria-haspopup] span div div, div.r-7o8qx1 div.r-axxi2z, div.css-1dbjc4n a.css-4rbku5 span.r-vw2c0b span.r-jwli3a, span span.r-jwli3a { display:none; } '; 
 
 
     var inverseDemetricatedStyle = '.ProfileCardStats-statValue, .ProfileTweet-actionCountForPresentation, .ProfileNav-value, a[data-tweet-stat-count] strong, .ep-MetricAnimation, .ep-MetricValue, .MomentCapsuleLikesFacepile-countNum, .stats li a strong { opacity:1 !important; } .count-wrap { display:unset !important; } div:not(.ProfileTweet-actionList)[aria-label="Tweet actions"] span, div[data-testid="like"] div span, div[data-testid="unlike"] div span, div[data-testid="reply"] div span, div[data-testid="retweet"] div span, div[data-testid="unretweet"] div span, div.r-z2knda.r-1wbh5a2 a > span:first-child, a.r-jwli3a[aria-haspopup="false"] span div div, div.r-7o8qx1 div.r-axxi2z, div.css-1dbjc4n a.css-4rbku5 span.r-vw2c0b, span span.r-jwli3a { display:inline !important; } '; 
@@ -545,11 +545,11 @@
             'div[aria-label="Timeline: Notifications"] article span span span',
             function(e) { demetricateMiddleMetricPopup(e); 
         });
-
+        
         function demetricateMiddleMetricPopup(e) {
             var txt = $(e).text();
             var htm = $(e).html();
-
+            
             if(txt != undefined && htm != undefined) {
 
                 var parsed;
@@ -563,6 +563,7 @@
                 }
 
                 if(parsed) {
+                    
                     var newhtml = parsed[1] + 
                         " <span class='notdemetricated' style='display:none;'>"+
                         parsed[2] + " </span>"+ parsed[3];
@@ -734,7 +735,7 @@
 
                 //$(e).css('border','2px solid green');
                 if(!newTwitter) return;
-
+                
                 /*
                  * defunct 3/25 - can't recall why i had this
                  * but no longer helping/working
@@ -759,7 +760,6 @@
                    let buttonLabel = buttons[i].attr('aria-label');
                    let buttonTest = buttons[i].attr('data-testid');
                    
-                    
                    // if buttonLabel starts w/ a num then there's a metric for this button
                    // OR if the button's data-testid is undefined, then it's *going* to get updated by React
                    if(buttonLabel != null && buttonLabel.match(/^\d/)!= 0 ) {
@@ -860,7 +860,7 @@
 
             });
         }
-
+        
         if(newTwitter) {
             ready('a[title]', function(e) {
                 let ttxt = $(e).attr('title');

--- a/chrome/td.user.js
+++ b/chrome/td.user.js
@@ -822,7 +822,7 @@
 
         // video views
         if(newTwitter) {
-            
+
             ready('div[data-testid = "videoPlayer"], div[data-testid = "previewInterstitial"]', function(e) {
                 let curr_parent = $(e).children()[1];
                 let views_div = $(curr_parent).children()[1];
@@ -835,8 +835,7 @@
 
             ready('div[data-testid = "placementTracking"] span:nth-child(1)', function(e) {
                 var txt = ($(e).text()).trim();
-                console.log(txt.includes("views"));
-                console.log($(e).text);
+
                 if(txt.includes("views")){
                     if($(e).hasClass("demetricator_checked")) return;
                     else $(e).addClass("demetricator_checked");

--- a/chrome/td.user.js
+++ b/chrome/td.user.js
@@ -113,8 +113,7 @@
     // a few metrics are easy, hidden via CSS. this style is mirrored in 
     // twitterdemetricator.css in order to inject *before* DOM renders on
     // first load, so need to maintain state in these vars plus that file
-    var demetricatedStyle = '.ProfileCardStats-statValue, .ProfileTweet-actionCountForPresentation, .ProfileNav-value, a[data-tweet-stat-count] strong, .ep-MetricAnimation, .ep-MetricValue, .MomentCapsuleLikesFacepile-countNum, .stats li a strong { opacity:0 !important; } .count-wrap { display:hide !important; } div:not(.ProfileTweet-actionList)[aria-label="Tweet actions"] span, div[data-testid="like"] div span, div[data-testid="unlike"] div span, div[data-testid="reply"] div span, div[data-testid="retweet"] div span, div[data-testid="unretweet"] div span, div.r-z2knda.r-1wbh5a2 a > span:first-child, a.r-jwli3a[aria-haspopup] span div div, div.r-7o8qx1 div.r-axxi2z, div.css-1dbjc4n a.css-4rbku5 span.r-vw2c0b span.r-jwli3a, span span.r-jwli3a { display:none; } '; 
-
+    var demetricatedStyle = '.ProfileCardStats-statValue, .ProfileTweet-actionCountForPresentation, .ProfileNav-value, a[data-tweet-stat-count] strong, .ep-MetricAnimation, .ep-MetricValue, .MomentCapsuleLikesFacepile-countNum, .stats li a strong { opacity:0 !important; } .count-wrap { display:hide !important; } div:not(.ProfileTweet-actionList)[aria-label="Tweet actions"] span, div[data-testid="like"] div span, div[data-testid="unlike"] div span, div[data-testid="reply"] div span, div[data-testid="retweet"] div span, div[data-testid="unretweet"] div span, div.r-z2knda.r-1wbh5a2 a > span:first-child, a.r-jwli3a[aria-haspopup] span div div, div.r-7o8qx1 div.r-axxi2z, div.css-1dbjc4n a.css-4rbku5 span.r-vw2c0b , span span.r-jwli3a { display:none; } '; 
 
     var inverseDemetricatedStyle = '.ProfileCardStats-statValue, .ProfileTweet-actionCountForPresentation, .ProfileNav-value, a[data-tweet-stat-count] strong, .ep-MetricAnimation, .ep-MetricValue, .MomentCapsuleLikesFacepile-countNum, .stats li a strong { opacity:1 !important; } .count-wrap { display:unset !important; } div:not(.ProfileTweet-actionList)[aria-label="Tweet actions"] span, div[data-testid="like"] div span, div[data-testid="unlike"] div span, div[data-testid="reply"] div span, div[data-testid="retweet"] div span, div[data-testid="unretweet"] div span, div.r-z2knda.r-1wbh5a2 a > span:first-child, a.r-jwli3a[aria-haspopup="false"] span div div, div.r-7o8qx1 div.r-axxi2z, div.css-1dbjc4n a.css-4rbku5 span.r-vw2c0b, span span.r-jwli3a { display:inline !important; } '; 
 
@@ -872,6 +871,20 @@
                 }
             });
         }
+
+
+        //verified account hidden through global demetricated style because the spans have the exact same class
+
+        ready( 'div.css-1dbjc4n a.css-4rbku5 span.r-vw2c0b', function(e){
+            //console.log($("div.css-1dbjc4n:contains('From ')"));
+            
+            var next_sib = $(e.nextSibling);
+            var verified = next_sib.find('svg');
+
+            if(verified && verified.attr('aria-label') == "Verified account"){
+                e.style = "display: inline !important";
+            }
+        });
 
         // others you follow in hovercards and profile pages
         // I'm removing some originally embedded markup here

--- a/chrome/td.user.js
+++ b/chrome/td.user.js
@@ -1037,18 +1037,13 @@
 
             // does sentence start with metric?
             var check = txt.match(/^\d/);
-            //console.log(txt)
-            //console.log(check)
+
             // if it does, clone, hide, insert demetricated version
             if(check) {
                 var orig = $(e);
                 var clone = orig.clone();
-                
-                //console.log('orig',orig);
-                //console.log('clone',clone);
                 clone.text(dTxt);
                 clone.css("color","white");
-                //console.log(clone.text(dTxt));
                 clone.addClass("demetricated");
                 orig.addClass("notdemetricated");
                 if(demetricated) orig.hide();

--- a/chrome/td.user.js
+++ b/chrome/td.user.js
@@ -822,7 +822,41 @@
 
         // video views
         if(newTwitter) {
+            ready('div[data-testid = "previewInterstitial"]', function(e) {
+                let curr_parent = $(e).children()[1];
+                let views_div = $(curr_parent).children()[1];
+                //console.log($(e).children()[1]);
+                //console.log($(curr_parent).children()[1]);
+                if($(views_div).hasClass("demetricator_checked")) return;
+                else $(views_div).addClass("demetricator_checked");
+                cloneAndDemetricateLeadingNum2($(views_div), "views");
+            });
+
+            ready('div[data-testid = "videoPlayer"]', function(e) {
+                let curr_parent = $(e).children()[1];
+                let views_div = $(curr_parent).children()[1];
+                //console.log(e);
+                //console.log($(e).children()[1]);
+                //console.log($(curr_parent).children()[1]);
+                if($(views_div).hasClass("demetricator_checked")) return;
+                else $(views_div).addClass("demetricator_checked");
+                cloneAndDemetricateLeadingNum2($(views_div), "views");
+            });
+
+            ready('div[data-testid = "placementTracking"]', function(e) {
+                let curr_parent = $(e).children()[1];
+                let views_div = $(curr_parent).children()[1];
+                console.log($("(e):contains('views')"));
+                //console.log($($(e).find('span')));
+                if($(views_div).hasClass("demetricator_checked")) return;
+                else $(views_div).addClass("demetricator_checked");
+                cloneAndDemetricateLeadingNum2($(views_div), "views");
+            });
+
+            //<span class="css-901oao css-16my406 r-1qd0xha r-ad9z0x r-bcqeeo r-qvutc0">88K views</span>
+
             ready('span[data-testid="viewCount"] span, div[data-testid="viewCount"] span', function(e) {
+                
                 if($(e).hasClass("demetricator_checked")) return;
                 else $(e).addClass("demetricator_checked");
                 cloneAndDemetricateLeadingNum($(e), "views");
@@ -1014,17 +1048,24 @@
 
             // does sentence start with metric?
             var check = txt.match(/^\d/);
-
+            //console.log(txt)
+            //console.log(check)
             // if it does, clone, hide, insert demetricated version
             if(check) {
                 var orig = $(e);
                 var clone = orig.clone();
+                
+                //console.log('orig',orig);
+                //console.log('clone',clone);
                 clone.text(dTxt);
+                clone.css("color","white");
+                //console.log(clone.text(dTxt));
                 clone.addClass("demetricated");
                 orig.addClass("notdemetricated");
                 if(demetricated) orig.hide();
                 else clone.hide();
                 clone.insertAfter(orig);
+                
             }
         }
 

--- a/chrome/td.user.js
+++ b/chrome/td.user.js
@@ -822,19 +822,12 @@
 
         // video views
         if(newTwitter) {
-            ready('div[data-testid = "previewInterstitial"]', function(e) {
+            
+            ready('div[data-testid = "videoPlayer"], div[data-testid = "previewInterstitial"]', function(e) {
                 let curr_parent = $(e).children()[1];
                 let views_div = $(curr_parent).children()[1];
 
-                if($(views_div).hasClass("demetricator_checked")) return;
-                else $(views_div).addClass("demetricator_checked");
-                cloneAndDemetricateLeadingNum2($(views_div), "views");
-            });
-
-            ready('div[data-testid = "videoPlayer"]', function(e) {
-                let curr_parent = $(e).children()[1];
-                let views_div = $(curr_parent).children()[1];
-
+                console.log($(e));
                 if($(views_div).hasClass("demetricator_checked")) return;
                 else $(views_div).addClass("demetricator_checked");
                 cloneAndDemetricateLeadingNum2($(views_div), "views");


### PR DESCRIPTION
The global demetricatedStyle causes this issue, specifically this line of code `div.css-1dbjc4n a.css-4rbku5 span.r-vw2c0b`. I was not able to find a different selector that would do the job without breaking some other metric functionality. So, I wrote a function to override the style for the specific case. It works perfectly for verified accounts. 
![Screen Shot 2020-09-21 at 1 17 52 AM](https://user-images.githubusercontent.com/14083340/93738554-b00f6600-fbab-11ea-9af4-96f18af01b45.png)
In the process however, I came across this example where it still incorrectly hides the name for other accounts. I have not found a fix for this yet. 
![Screen Shot 2020-09-21 at 1 19 39 AM](https://user-images.githubusercontent.com/14083340/93738580-c4ebf980-fbab-11ea-964c-00f6ecb30b51.png)

Tl;dr Fixed bug only for verified accounts in all views  #9 
